### PR TITLE
Remove Node.js setup from Rust CI workflow

### DIFF
--- a/.github/workflows/Rust CI.yml
+++ b/.github/workflows/Rust CI.yml
@@ -18,10 +18,6 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20'
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install rustfmt


### PR DESCRIPTION
This pull request removes the Node.js setup from the Rust CI workflow. The previous setup was unnecessary and has been removed to streamline the workflow.